### PR TITLE
fix: prevent Bangumi calendar crash when API returns non-array data

### DIFF
--- a/src/lib/bangumi.client.ts
+++ b/src/lib/bangumi.client.ts
@@ -3,35 +3,74 @@
 export interface BangumiCalendarData {
   weekday: {
     en: string;
+    cn?: string;
+    ja?: string;
+    id?: number;
   };
   items: {
     id: number;
     name: string;
-    name_cn: string;
-    rating: {
-      score: number;
+    name_cn?: string;
+    rating?: {
+      total?: number;
+      count?: Record<string, number>;
+      score?: number;
     };
-    air_date: string;
-    images: {
-      large: string;
-      common: string;
-      medium: string;
-      small: string;
-      grid: string;
+    air_date?: string;
+    air_weekday?: number;
+    rank?: number;
+    images?: {
+      large?: string;
+      common?: string;
+      medium?: string;
+      small?: string;
+      grid?: string;
     };
+    collection?: {
+      doing?: number;
+    };
+    url?: string;
+    type?: number;
+    summary?: string;
   }[];
 }
 
 export async function GetBangumiCalendarData(): Promise<BangumiCalendarData[]> {
-  const response = await fetch('/api/bangumi/calendar');
-  if (!response.ok) {
-    throw new Error(`获取番剧日历失败: HTTP ${response.status}`);
-  }
-  const data = await response.json();
-  const filteredData = data.map((item: BangumiCalendarData) => ({
-    ...item,
-    items: item.items.filter(bangumiItem => bangumiItem.images)
-  }));
+  try {
+    const response = await fetch('/api/bangumi/calendar');
 
-  return filteredData;
+    if (!response.ok) {
+      console.error('获取番剧日历失败: HTTP', response.status);
+      return [];
+    }
+
+    const data = await response.json();
+
+    // Safety check: ensure API returned an array
+    if (!Array.isArray(data)) {
+      console.error('获取番剧日历失败: API 返回了非数组数据');
+      return [];
+    }
+
+    const filteredData = data
+      .filter((item: unknown): item is BangumiCalendarData => {
+        return (
+          item !== null &&
+          typeof item === 'object' &&
+          'weekday' in item &&
+          'items' in item
+        );
+      })
+      .map((item: BangumiCalendarData) => ({
+        ...item,
+        items: Array.isArray(item.items)
+          ? item.items.filter((bangumiItem) => bangumiItem?.images)
+          : [],
+      }));
+
+    return filteredData;
+  } catch (error) {
+    console.error('获取番剧日历失败:', error);
+    return [];
+  }
 }


### PR DESCRIPTION
## 问题

Bangumi 番剧日历在 Bangumi API 不可达或返回错误时会导致首页崩溃，报错 `eU.find is not a function`（编译后变量名）。

### 根因

`GetBangumiCalendarData()` 没有防御性检查。当 Bangumi API 返回非数组数据（如 `{ error: "..." }`）时，`data.map()` 抛异常。该异常被 `Promise.allSettled` 捕获后，bangumiCalendarData 状态保持为 `[]` 不乱，但如果客户端代码缺少 `response.ok` 检查，错误对象会被直接传给 `setBangumiCalendarData`，导致 `.find()` 崩溃。

### 修复

1. **`Array.isArray` 检查**: 在调用 `.map()` 前验证 `data` 是数组，不是则返回 `[]`
2. **防御性返回**: 将 `throw` 改为 `console.error + return []`
3. **try-catch 包裹**: 捕获任何意外错误，保证始终返回数组
4. **类型安全**: 将 BangumiCalendarData 中可能缺失的字段标记为可选（`?`）
5. **空值安全**: 对 `item.items` 加了 `Array.isArray` 和 `?.` 检查

## 测试

- Bangumi API 正常 → 正常返回数组，行为不变
- Bangumi API 超时/被墙 → 返回 `[]`，首页不崩溃，日历模块不显示
- Bangumi API 返回非数组 JSON → 返回 `[]`，安全

## 相关

Fixes Bangumi 日历模块在 CN 环境下因 API 被墙/超时导致的首页崩溃。